### PR TITLE
Fix release job

### DIFF
--- a/.github/workflows/monitoring-demo-api.yaml
+++ b/.github/workflows/monitoring-demo-api.yaml
@@ -26,10 +26,6 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Debug build flags
-        run: "echo expression: ${{ github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' ) }}"
-      - run: "echo event     : ${{ github.event_name }}"
-      - run: "echo ref       : ${{ github.ref }}"
       - name: Build image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/promql/docker-compose.yml
+++ b/promql/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   grafana:
-    image: grafana/grafana:7.5.11
+    image: grafana/grafana:8.2.2
     ports:
       - "3000:3000"
     networks:
@@ -17,7 +17,7 @@ services:
     volumes:
       - ${PROMQLWD}/assets/prometheus:/etc/prometheus
   mondemoapi:
-    image: ghcr.io/ing-bank/prometheus-scenarios/monitoring-demo-api:v0.0.7
+    image: ghcr.io/ing-bank/prometheus-scenarios/monitoring-demo-api:v0.0.10
     ports:
       - "8080:8080"
     networks:


### PR DESCRIPTION
Fixed workflow to push the docker image when a tag is placed
Removed debug logic from the release workflow
Upgraded Grafana to 8.2.2
Prepared for release v0.0.10